### PR TITLE
Once completed, lock score by checking self.completed

### DIFF
--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -148,11 +148,13 @@ class MentoringBlock(XBlockWithLightChildren):
         elif completed and self.next_step == self.url_name:
             self.next_step = self.followed_by
 
-        score = sum(r[1]['score'] for r in submit_results) / float(len(submit_results))
-        self.runtime.publish(self, 'grade', {
-            'value': score,
-            'max_value': 1,
-        })
+        # Once it was completed, lock score
+        if not self.completed:
+            score = sum(r[1]['score'] for r in submit_results) / float(len(submit_results))
+            self.runtime.publish(self, 'grade', {
+                'value': score,
+                'max_value': 1,
+            })
 
         if not self.completed and self.max_attempts > 0:
             self.num_attempts += 1


### PR DESCRIPTION
Fix a bug found by QA.

This implementation makes the following assumptions, please let me know if they are erroneous:
- Before being completed a Block will have submitted grade at least once (this might not be true if grading is deployed on top of already live Blocks)
- Once completed, a score can't be increased or changed anyway
