### PR TITLE
Added a title element

### DIFF
--- a/mentoring/__init__.py
+++ b/mentoring/__init__.py
@@ -8,3 +8,4 @@ from .mentoring import MentoringBlock
 from .message import MentoringMessageBlock
 from .table import MentoringTableBlock, MentoringTableColumnBlock, MentoringTableColumnHeaderBlock
 from .tip import TipBlock
+from .title import TitleBlock

--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -34,6 +34,7 @@ from xblock.fields import Boolean, Scope, String, Integer, Float
 from xblock.fragment import Fragment
 
 from .light_children import XBlockWithLightChildren
+from .title import TitleBlock
 from .message import MentoringMessageBlock
 from .utils import get_scenarios_from_path, load_resource, render_template
 
@@ -79,7 +80,7 @@ class MentoringBlock(XBlockWithLightChildren):
     def student_view(self, context):
         fragment, named_children = self.get_children_fragment(
             context, view_name='mentoring_view',
-            not_instance_of=MentoringMessageBlock
+            not_instance_of=(MentoringMessageBlock, TitleBlock)
         )
 
         fragment.add_content(render_template('templates/html/mentoring.html', {
@@ -96,6 +97,16 @@ class MentoringBlock(XBlockWithLightChildren):
         fragment.initialize_js('MentoringBlock')
 
         return fragment
+
+    @property
+    def title(self):
+        """
+        Returns the title child.
+        """
+        for child in self.get_children_objects():
+            if isinstance(child, TitleBlock):
+                return child
+        return None
 
     @property
     def has_missing_dependency(self):

--- a/mentoring/templates/html/mentoring.html
+++ b/mentoring/templates/html/mentoring.html
@@ -3,6 +3,9 @@
     You need to complete <a href="{{ missing_dependency_url }}">the previous step</a> before
     attempting this step.
   </div>
+  {% if self.title %}
+  <h2>{{ self.title.content }} {% if self.weight %} ({{ self.weight }} Points Possible) {% endif %}</h2>
+  {% endif %}
   {% for name, c in named_children %}
   {{c.body_html|safe}}
   {% endfor %}

--- a/mentoring/title.py
+++ b/mentoring/title.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014 Harvard
+#
+# Authors:
+#          Xavier Antoviaque <xavier@antoviaque.org>
+#
+# This software's license gives you freedom; you can copy, convey,
+# propagate, redistribute and/or modify this program under the terms of
+# the GNU Affero General Public License (AGPL) as published by the Free
+# Software Foundation (FSF), either version 3 of the License, or (at your
+# option) any later version of the AGPL published by the FSF.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program in a file in the toplevel directory called
+# "AGPLv3".  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Imports ###########################################################
+
+import logging
+
+from .light_children import LightChild, Scope, String
+
+# Globals ###########################################################
+
+log = logging.getLogger(__name__)
+
+# Classes ###########################################################
+
+class TitleBlock(LightChild):
+    """
+    A simple html representation of a title, with the mentoring weight.
+    """
+    content = String(help="Text to display", scope=Scope.content, default="")

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ BLOCKS_CHILDREN = [
     'message = mentoring:MentoringMessageBlock',
     'tip = mentoring:TipBlock',
     'choice = mentoring:ChoiceBlock',
-    'html = mentoring:HTMLBlock'
+    'html = mentoring:HTMLBlock',
+    'title = mentoring:TitleBlock'
 ]
 
 setup(


### PR DESCRIPTION
- Added a title element available in the xml to display a title with/without the weight.
- My first idea was to make something completely independent, so the rendering would have be only in the title.py. However, the mentoring and title object are strongly related themself since the Title depends on the Mentoring.weight and that we won't use the <title> element anywhere else in the document since it won't make sense cause of the weight thing. Note that we could have also put this in a simple attribute of the <mentoring> element, but perhaps this element will change in the future and be more complex? 

In any case, let me know if you want me to change something.
