### PR TITLE
feedback-no-max-height: Removing max-height on feedback element

### DIFF
--- a/mentoring/public/css/questionnaire.css
+++ b/mentoring/public/css/questionnaire.css
@@ -42,7 +42,6 @@
     font-family: arial;
     font-size: 14px;
     height: 100%;
-    max-height: 100%;
     opacity: 0.9;
     padding: 10px;
     width: 300px;


### PR DESCRIPTION
@aboudreault FYI, removing the max-height upon client request, as the height of the MCQ is not enough to contain certain answers. We should probably come back to improve this later on, to push elements down as previously discussed when the feedback is too tall.
