### PR TITLE
Update display when answer is changed.

### DIFF
--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -138,6 +138,13 @@ class MentoringBlock(XBlockWithLightChildren):
                 child.save()
                 completed = completed and child_result['completed']
 
+        if self.max_attempts_reached:
+            message = self.get_message_html('max_attempts_reached')
+        elif completed:
+            message = self.get_message_html('completed')
+        else:
+            message = self.get_message_html('incomplete')
+
         # Once it has been completed once, keep completion even if user changes values
         if self.completed:
             completed = True
@@ -145,13 +152,6 @@ class MentoringBlock(XBlockWithLightChildren):
         # server-side check to not set completion if the max_attempts is reached
         if self.max_attempts_reached:
             completed = False
-
-        if completed:
-            message = self.get_message_html('completed')
-        elif self.max_attempts_reached:
-            message = self.get_message_html('max_attempts_reached')
-        else:
-            message = self.get_message_html('incomplete')
 
         if self.has_missing_dependency:
             completed = False

--- a/mentoring/public/js/answer.js
+++ b/mentoring/public/js/answer.js
@@ -3,7 +3,7 @@ function AnswerBlock(runtime, element) {
 
         init: function(options) {
             // register the child validator
-            $(':input', element).on('keyup', options.blockValidator);
+            $(':input', element).on('keyup', _.debounce(options.onChange, 1000));
 
             var checkmark = $('.answer-checkmark', element);
             var completed = $('.xblock-answer', element).data('completed');

--- a/mentoring/public/js/questionnaire.js
+++ b/mentoring/public/js/questionnaire.js
@@ -46,7 +46,7 @@ function MessageView(element) {
 function MCQBlock(runtime, element) {
     return {
         init: function(options) {
-            $('input[type=radio]', element).on('change', options.blockValidator);
+            $('input[type=radio]', element).on('change', options.onChange);
         },
 
         submit: function() {
@@ -123,7 +123,7 @@ function MCQBlock(runtime, element) {
 function MRQBlock(runtime, element) {
     return {
         init: function(options) {
-            $('input[type=checkbox]', element).on('change', options.blockValidator);
+            $('input[type=checkbox]', element).on('change', options.onChange);
         },
 
         submit: function() {


### PR DESCRIPTION
When the user first submits the answers, the checkmark/cross icons,
tip popups, and a message are shown to the user.

If the user changes some of the answers, the checkmarks, popups, and message
should automatically update. This is done by automatically resubmitting the answer.
Auto submission is only enabled if number of attempts is not limited (max_attempts = 0),
