### PR TITLE
Use StringIO instead of cStringIO to support Unicode in LightChildren

### DIFF
--- a/mentoring/light_children.py
+++ b/mentoring/light_children.py
@@ -29,7 +29,7 @@ import json
 from lazy import lazy
 from weakref import WeakKeyDictionary
 
-from cStringIO import StringIO
+from StringIO import StringIO
 from lxml import etree
 
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
From the cStringIO docs:

> Unlike the StringIO module, this module is not able to accept Unicode strings that cannot be encoded as plain ASCII strings.

Traceback

```
Traceback (most recent call last): 
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/modulestore/mongo/base.py", line 188, in load_item module = self.construct_xblock_from_class(class_, scope_ids, field_data) 
File "/edx/app/edxapp/venvs/edxapp/src/xblock/xblock/runtime.py", line 477, in construct_xblock_from_class *args, **kwargs 
File "/edx/app/edxapp/venvs/edxapp/src/xblock-mentoring/mentoring/light_children.py", line 170, in __init__ self.load_children_from_xml_content() 
File "/edx/app/edxapp/venvs/edxapp/src/xblock-mentoring/mentoring/light_children.py", line 129, in load_children_from_xml_content node = etree.parse(StringIO(self.xml_content)).getroot() 
UnicodeEncodeError: 'ascii' codec can't encode character u'\u201c' in position 500: ordinal not in range(128)
```
