### PR TITLE
Tip overflow

### DIFF
--- a/mentoring/public/css/mentoring.css
+++ b/mentoring/public/css/mentoring.css
@@ -80,10 +80,6 @@
     float: left;
 }
 
-.mentoring div {
-    overflow: hidden;
-}
-
 .mentoring .choice-result{
     display:block;
     float: left;

--- a/mentoring/public/css/questionnaire.css
+++ b/mentoring/public/css/questionnaire.css
@@ -17,6 +17,10 @@
     cursor: pointer;
 }
 
+.mentoring .questionnaire .choice {
+    overflow-y: hidden;
+}
+
 .mentoring .questionnaire .choice-result.checkmark-correct,
 .mentoring .questionnaire .choice-result.checkmark-incorrect {
     text-align:center;
@@ -32,7 +36,8 @@
     background: none repeat scroll 0 0 #66A5B5;
     font-family: arial;
     font-size: 14px;
-    height: 100%;
+    height: 130%;
+    overflow-y: auto;
     opacity: 0.9;
     padding: 10px;
     width: 300px;


### PR DESCRIPTION
Add scrollbar to feedback popup when the text exceeds the size of the display element. Also allow to force resizing beyond the mentoring block size through the `height` attribute of `<tip>` elements.

@aboudreault Want to review? Feel free to ask questions.
