### PR TITLE
Only close the feedback popup when clicking on the close 'x' button

### DIFF
--- a/mentoring/public/js/questionnaire.js
+++ b/mentoring/public/js/questionnaire.js
@@ -28,7 +28,7 @@ function MessageView(element) {
             }
 
             popupDOM.show();
-            popupDOM.on('click', function() {
+            $('.close', popupDOM).on('click', function() {
                 self.clearPopupEvents();
             });
         },


### PR DESCRIPTION
It used to close when any part of the popup would be clicked.

@aboudreault Can you review? Thanks!
