### PR TITLE
display-name: Update usage of `display_name` to include upstream changes

### DIFF
--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -83,6 +83,8 @@ class MentoringBlock(XBlockWithLightChildren):
     student_results = List(help="Store results of student choices.", default=[],
                            scope=Scope.user_state)
 
+    display_name = String(help="Display name of the component", default="Mentoring XBlock",
+                          scope=Scope.settings)
     icon_class = 'problem'
     has_score = True
 
@@ -403,14 +405,3 @@ class MentoringBlock(XBlockWithLightChildren):
         Scenarios displayed by the workbench. Load them from external (private) repository
         """
         return get_scenarios_from_path('templates/xml')
-
-    @property
-    def display_name_with_default(self):
-        """
-        Return a display name for the module: use display_name if defined in
-        metadata, otherwise use a custom default value.
-        """
-        name = self.display_name
-        if name is None:
-            name = "Mentoring Block"
-        return name


### PR DESCRIPTION
It used to be on a separate property - it's now using a real XBlock field and its default value

@mtyaka @aboudreault Want to review?
