### PR TITLE
Keep submit button disabled after answering in assessment.

### DIFF
--- a/mentoring/public/js/mentoring_assessment_view.js
+++ b/mentoring/public/js/mentoring_assessment_view.js
@@ -112,7 +112,12 @@ function MentoringAssessmentView(runtime, element, mentoring) {
     }
 
     function onChange() {
-        validateXBlock();
+        // Assessment mode does not allow to modify answers.
+        // Once an answer has been submitted (next button is enabled),
+        // start ignoring changes to the answer.
+        if (nextDOM.attr('disabled')) {
+            validateXBlock();
+        }
     }
 
     function handleSubmitResults(result) {


### PR DESCRIPTION
Once a student submits an answer in assessment mode, he should not be allowed
to change it, so stop listening for changes once an answer has been submitted.

The change lister would re-enable the submit button if the student changed their
answer, which shouldn't happen in assessment mode.
