### PR TITLE
Tracking logs

### DIFF
--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -141,10 +141,6 @@ class MentoringBlock(XBlockWithLightChildren):
 
         fragment.initialize_js('MentoringBlock')
 
-        self.runtime.publish(self, 'mentoring.problem.shown',
-                {'component_id': self.scope_ids.usage_id, 'user_id': self.runtime.user_id}
-        )
-
         return fragment
 
     @XBlock.json_handler
@@ -247,7 +243,7 @@ class MentoringBlock(XBlockWithLightChildren):
 
         raw_score = self.score[0]
 
-        self.runtime.publish(self, 'mentoring.problem.attempted', {
+        self.runtime.publish(self, 'xblock.mentoring.submitted', {
             'component_id': self.scope_ids.usage_id,
             'user_id': self.runtime.user_id,
             'num_attempts': self.num_attempts,

--- a/mentoring/public/js/mentoring.js
+++ b/mentoring/public/js/mentoring.js
@@ -92,4 +92,10 @@ function MentoringBlock(runtime, element) {
     else if (data.mode === 'assessment') {
         MentoringAssessmentView(runtime, element, mentoring);
     }
+
+    $.ajax({
+        type: "POST",
+        url: runtime.handlerUrl(element, 'publish_event'),
+        data: JSON.stringify({event_type:"xblock.mentoring.loaded"})
+    });
 }

--- a/mentoring/public/js/questionnaire.js
+++ b/mentoring/public/js/questionnaire.js
@@ -27,16 +27,22 @@ function MessageView(element) {
                 popupDOM.css('height', '')
             }
 
-
             popupDOM.show();
-            $('.close', popupDOM).on('click', function() {
-                self.clearPopupEvents();
-                console.log(popupDOM);
+
+            function publish_event(data) {
                 $.ajax({
                     type: "POST",
                     url: runtime.handlerUrl(element, 'publish_event'),
-                    data: JSON.stringify({event_type:'mentoring.feedback.closed'})
+                    data: JSON.stringify(data)
                 });
+            }
+
+            publish_event({event_type:'xblock.mentoring.feedback.opened'});
+
+            $('.close', popupDOM).on('click', function() {
+                self.clearPopupEvents();
+                console.log(popupDOM);
+                publish_event({event_type:'xblock.mentoring.feedback.closed'});
             });
         },
         showMessage: function(message) {


### PR DESCRIPTION
`feedback.shown` is not implemented, since it is already implied by a `problem.attempted` event. There is no other way to trigger a feedback.

It would be nice to add an `item_id` to the `feedback.closed` event. It might be a good idea, and relatively easy, but that would include giving IDs for each feedback, meaning some extra work and code.
