### PR TITLE
Line-wrap legend elements in IE.

### DIFF
--- a/mentoring/public/css/mentoring.css
+++ b/mentoring/public/css/mentoring.css
@@ -57,6 +57,11 @@
     display: none;
 }
 
+.mentoring legend {
+    white-space: normal;
+    display: table; /* Enable line-wrapping in IE8 */
+}
+
 .mentoring .attempts {
     margin-left: 10px;
     display: inline-block;


### PR DESCRIPTION
IE8+ (including IE11) does not wrap the content of legend elements.

Since questions that we put into legend elements can get quite long,
the question would overflow the page in IE.

Adding display:table rule to the legend element forces the legend text
to wrap in IE, without any negative side-effects in other browsers.

See:
http://www.456bereastreet.com/archive/201210/how_to_line_wrap_text_in_legend_elements_even_in_ie
http://stackoverflow.com/questions/6133571/how-can-i-make-legend-text-wrap
