### PR TITLE
MCKIN-2175 Remove popup html on clearResult call and add popup text only...

### DIFF
--- a/mentoring/public/js/questionnaire.js
+++ b/mentoring/public/js/questionnaire.js
@@ -53,7 +53,7 @@ function MessageView(element, mentoring) {
             }
         },
         clearResult: function() {
-            this.allPopupsDOM.hide();
+            this.allPopupsDOM.html('').hide();
             this.allResultsDOM.removeClass(
                 'checkmark-incorrect icon-exclamation fa-exclamation checkmark-correct icon-ok fa-check'
             );
@@ -101,7 +101,7 @@ function MCQBlock(runtime, element, mentoring) {
                     choiceResultDOM.addClass('checkmark-incorrect icon-exclamation fa-exclamation');
                 }
 
-                if (result.tips) {
+                if (result.tips && choiceInputDOM.val() === result.submission) {
                     mentoring.setContent(choiceTipsDOM, result.tips);
                 }
 


### PR DESCRIPTION
... to answer it pertains to

I'm not sure this was the intended behavior.
With this once you submit the answer you get feedback popup. When any other answer is clicked popup is hidden and you can't see it again until resubmit. Clicking left of answer shouldn't show anything.
