### PR TITLE
Assessments: Don't reactivate the submit button upon retry

### DIFF
--- a/mentoring/public/js/mentoring_assessment_view.js
+++ b/mentoring/public/js/mentoring_assessment_view.js
@@ -46,7 +46,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         active_child = -1;
         displayNextChild();
         tryAgainDOM.hide();
-        submitDOM.show().removeAttr('disabled');
+        submitDOM.show();
         nextDOM.show();
     }
 


### PR DESCRIPTION
@aboudreault Was there a reason for explicitly removing the disabled attribute on the submit button upon retrying an assessment? To make sure I'm not breaking another part by fixing this.
