### PR TITLE
Opaque keys follow up

### DIFF
--- a/mentoring/answer.py
+++ b/mentoring/answer.py
@@ -31,7 +31,7 @@ from xblock.fragment import Fragment
 
 from .light_children import LightChild, Boolean, Scope, String, Integer, Float
 from .models import Answer
-from .utils import render_js_template, serialize_opaque_key
+from .utils import render_js_template
 
 
 # Globals ###########################################################
@@ -144,7 +144,7 @@ class AnswerBlock(LightChild):
 
         # TODO: Why do we need to use `xmodule_runtime` and not `runtime`?
         student_id = self.xmodule_runtime.anonymous_student_id
-        course_id = serialize_opaque_key(self.xmodule_runtime.course_id)
+        course_id = self.xmodule_runtime.course_id
 
         answer_data, created = Answer.objects.get_or_create(
             student_id=student_id,

--- a/mentoring/dataexport.py
+++ b/mentoring/dataexport.py
@@ -32,7 +32,7 @@ from xblock.fields import String, Scope
 from xblock.fragment import Fragment
 
 from .models import Answer
-from .utils import list2csv, render_template, serialize_opaque_key
+from .utils import list2csv, render_template
 
 
 # Globals ###########################################################
@@ -73,7 +73,7 @@ class MentoringDataExportBlock(XBlock):
         return response
 
     def get_csv(self):
-        course_id = serialize_opaque_key(self.xmodule_runtime.course_id)
+        course_id = self.xmodule_runtime.course_id
 
         answers = Answer.objects.filter(course_id=course_id).order_by('student_id', 'name')
         answers_names = answers.values_list('name', flat=True).distinct().order_by('name')

--- a/mentoring/light_children.py
+++ b/mentoring/light_children.py
@@ -47,7 +47,7 @@ except:
     # TODO-WORKBENCH-WORKAROUND: To allow to load from the workbench
     replace_jump_to_id_urls = lambda a, b, c, d, frag, f: frag
 
-from .utils import serialize_opaque_key, XBlockWithChildrenFragmentsMixin
+from .utils import XBlockWithChildrenFragmentsMixin
 
 
 # Globals ###########################################################
@@ -190,7 +190,7 @@ class XBlockWithLightChildren(LightChildrenMixin, XBlock):
         """
         # TODO: Why do we need to use `xmodule_runtime` and not `runtime`?
         try:
-            course_id = serialize_opaque_key(self.xmodule_runtime.course_id)
+            course_id = self.xmodule_runtime.course_id
         except AttributeError:
             # TODO-WORKBENCH-WORKAROUND: To allow to load from the workbench
             course_id = 'sample-course'
@@ -303,7 +303,7 @@ class LightChild(Plugin, LightChildrenMixin):
             raise ValueError('LightChild.name field need to be set to a non-null/empty value')
 
         student_id = self.xmodule_runtime.anonymous_student_id
-        course_id = serialize_opaque_key(self.xmodule_runtime.course_id)
+        course_id = self.xmodule_runtime.course_id
         url_name = "%s-%s" % (self.xblock_container.url_name, name)
 
         lightchild_data, created = LightChildModel.objects.get_or_create(

--- a/mentoring/utils.py
+++ b/mentoring/utils.py
@@ -110,29 +110,6 @@ def load_scenarios_from_path(scenarios_path):
     return get_scenarios_from_path(scenarios_path, include_identifier=True)
 
 
-def serialize_opaque_key(key):
-    """
-    Gracefully handle opaque keys, both before and after the transition.
-    https://github.com/edx/edx-platform/wiki/Opaque-Keys-(Locators)
-
-    From https://github.com/edx/edx-ora2/pull/330
-
-    Currently uses `to_deprecated_string()` to ensure that new keys
-    are backwards-compatible with keys we store in mentoring database models.
-
-    Args:
-    key (unicode or OpaqueKey subclass): The key to serialize.
-
-    Returns:
-    unicode
-
-    """
-    if hasattr(key, 'to_deprecated_string'):
-        return key.to_deprecated_string()
-    else:
-        return unicode(key)
-
-
 # Classes ###########################################################
 
 class XBlockWithChildrenFragmentsMixin(object):


### PR DESCRIPTION
Same as gsehub/xblock-mentoring#8. The `serialize_opaque_key` method has been removed, since the handling of deprecated keys and opaque keys is now handled automatically by `OpaqueKey. __unicode__()` in `opaque-keys/opaque_keys/__init__.py`.
