### PR TITLE
Fix feedback overflow for long texts

### DIFF
--- a/mentoring/public/css/mentoring.css
+++ b/mentoring/public/css/mentoring.css
@@ -129,3 +129,7 @@
 .mentoring input[type="radio"] {
     margin: 0;
 }
+
+.mentoring .feedback {
+    max-height: 100%;
+}


### PR DESCRIPTION
When feedback text is long feedback block could stretch beyond it's parent element height and overlap with other questions' feedbacks.

This PR fixes this by setting feedback block max-height to 100%, which means it would never exceed its' parent height.