### PR TITLE
Immediately send progress on disable submit

### DIFF
--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -97,7 +97,8 @@ class MentoringBlock(XBlockWithLightChildren, StepParentMixin):
                       default='mentoring-default', scope=Scope.content)
     enforce_dependency = Boolean(help="Should the next step be the current block to complete?",
                                  default=False, scope=Scope.content, enforce_type=True)
-    display_submit = Boolean(help="Allow to submit current block?", default=True, scope=Scope.content)
+    display_submit = Boolean(help="Allow submission of the current block?", default=True,
+                             scope=Scope.content, enforce_type=True)
     xml_content = String(help="XML content", default=_default_xml_content, scope=Scope.content)
     weight = Float(help="Defines the maximum total grade of the block.",
                    default=1, scope=Scope.content, enforce_type=True)
@@ -171,6 +172,9 @@ class MentoringBlock(XBlockWithLightChildren, StepParentMixin):
         fragment.add_resource(loader.load_unicode('templates/html/mentoring_grade.html'), "text/html")
 
         fragment.initialize_js('MentoringBlock')
+
+        if not self.display_submit:
+            self.runtime.publish(self, 'progress', {})
 
         return fragment
 

--- a/tests/integration/test_mentoring.py
+++ b/tests/integration/test_mentoring.py
@@ -1,0 +1,9 @@
+from selenium.common.exceptions import NoSuchElementException
+from tests.integration.base_test import MentoringBaseTest
+
+
+class MentoringTest(MentoringBaseTest):
+    def test_display_submit_false_does_not_display_submit(self):
+        mentoring = self.go_to_page('No Display Submit')
+        with self.assertRaises(NoSuchElementException):
+            mentoring.find_element_by_css_selector('.submit input.input-main')

--- a/tests/integration/xml/no_display_submit.xml
+++ b/tests/integration/xml/no_display_submit.xml
@@ -1,0 +1,5 @@
+<vertical_demo>
+    <mentoring url_name="answer_blank_read_only" enforce_dependency="false" display_submit="false">
+        <answer name="answer_blank"/>
+    </mentoring>
+</vertical_demo>

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 ddt
 unicodecsv==0.9.4
+mock
 
 -e git+https://github.com/edx-solutions/XBlock.git@b5acb81ad5b6fa02f53a7434c69ee87c4cc15950#egg=XBlock
 -e git+https://github.com/edx-solutions/xblock-sdk.git@574ce51ca7f87213e1d8ba2f0365d32126a9030b#egg=xblock-sdk

--- a/tests/unit/test_mentoring.py
+++ b/tests/unit/test_mentoring.py
@@ -1,0 +1,30 @@
+import unittest
+from mock import MagicMock, Mock, patch
+from xblock.field_data import DictFieldData
+from mentoring import MentoringBlock
+
+
+class TestMentoringBlock(unittest.TestCase):
+    def test_sends_progress_event_when_rendered_student_view_with_display_submit_false(self):
+        block = MentoringBlock(MagicMock(), DictFieldData({
+            'display_submit': False
+        }), Mock())
+
+        with patch.object(block, 'runtime') as patched_runtime:
+            patched_runtime.publish = Mock()
+
+            block.student_view(context={})
+
+            patched_runtime.publish.assert_called_once_with(block, 'progress', {})
+
+    def test_does_not_send_progress_event_when_rendered_student_view_with_display_submit_true(self):
+        block = MentoringBlock(MagicMock(), DictFieldData({
+            'display_submit': True
+        }), Mock())
+
+        with patch.object(block, 'runtime') as patched_runtime:
+            patched_runtime.publish = Mock()
+
+            block.student_view(context={})
+
+            self.assertFalse(patched_runtime.publish.called)


### PR DESCRIPTION
Concern: modifications to `light_children.py` contains in-function import, which is added to break circular import. There reason why `MentoringBlock` is needed there is to fix a subtle bug in how light_children parses XML and sets attributes on blocks.

In short it was skipping XBlock Fields' deserialization and just assigned string values to block attributes - hence display_submit worked incorrectly, as string "false" is true-ish in boolean context. The workaround is to check if we're setting data for `MentoringBlock` (as the only XBlock with real XBlock Fields) and force parsing the value with appropriate Field.

Since we have mentoring-v2 (aka "real chilrden") almost ready, `light_children` modifications should be viewed as a temporary workaround for a problem, as mentoring-v2 would not be subject to this issue.