### PR TITLE
Add ability to hide QUESTION titles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ answer element supports the following attributes:
   only makes sense when displaying an answer to a previously answered
   question. The answer is rendered as a HTML quote instead of a
   textarea element (boolean; defaults to `false`).
+* `show_title` - Whether to display the title (QUESTION num) above the
+  question (boolean; defaults to `true`).
 
 It can also have a `<question>` element containing a paragraph of non-formatted plain text.
 
@@ -198,6 +200,8 @@ Multiple choice questions are represented by the `<mcq>` element. The
   questions of the `rating` type (string; defaults to `"Less"`).
 * `high` - Sets the label of the lowest value. Only makes sense for
   questions of the `rating` type (string; defaults to `"More"`).
+* `show_title` - Whether to display the title (QUESTION num) above the
+  question (boolean; defaults to `true`).
 
 The `<mcq>` element can contain the following child elements:
 
@@ -287,6 +291,8 @@ The `<mrq>` element supports these attributes:
   question will have on the grade. Value of zero means this question
   has no influence on the grade (float, defaults to `1`).
 * `hide_results` - If set to `true`, the feedback icons next to each
+* `show_title` - Whether to display the title (QUESTION num) above the
+  question (boolean; defaults to `true`).
   choice will not be displayed (boolean; defaults to `false`).
 
 The `<question>` and `<choice>` elements work the same way as they

--- a/mentoring/answer.py
+++ b/mentoring/answer.py
@@ -49,6 +49,7 @@ class AnswerBlock(LightChild, StepMixin):
     Must be included as a child of a mentoring block. Answers are persisted as django model instances
     to make them searchable and referenceable across xblocks.
     """
+    show_title = Boolean(help="Display the default title (QUESTION)?", default=True, scope=Scope.content)
     read_only = Boolean(help="Display as a read-only field", default=False, scope=Scope.content)
     default_from = String(help="If specified, the name of the answer to get the default value from",
                           default=None, scope=Scope.content)

--- a/mentoring/questionnaire.py
+++ b/mentoring/questionnaire.py
@@ -31,7 +31,7 @@ from xblock.fragment import Fragment
 
 from .choice import ChoiceBlock
 from .step import StepMixin
-from .light_children import LightChild, Scope, String, Float
+from .light_children import LightChild, Scope, String, Float, Boolean
 from .tip import TipBlock
 from .utils import loader, ContextConstants
 
@@ -52,6 +52,7 @@ class QuestionnaireAbstractBlock(LightChild, StepMixin):
     set, with preset choices and author-defined values.
     """
     type = String(help="Type of questionnaire", scope=Scope.content, default="choices")
+    show_title = Boolean(help="Display the default title (QUESTION)?", default=True, scope=Scope.content)
     question = String(help="Question to ask the student", scope=Scope.content, default="")
     message = String(help="General feedback provided when submiting", scope=Scope.content, default="")
     weight = Float(help="Defines the maximum total grade of the light child block.",

--- a/mentoring/templates/html/answer_editable.html
+++ b/mentoring/templates/html/answer_editable.html
@@ -1,5 +1,7 @@
 <div class="xblock-answer" data-completed="{{ self.completed }}">
-  <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+  {% if self.show_title %}
+    <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+  {% endif %}
   <p>{{ self.question }}</p>
   <textarea
      class="answer editable" cols="50" rows="10" name="input"

--- a/mentoring/templates/html/answer_read_only.html
+++ b/mentoring/templates/html/answer_read_only.html
@@ -1,5 +1,7 @@
 <div class="xblock-answer" data-completed="{{ self.completed }}">
-  <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+  {% if self.show_title %}
+    <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+  {% endif %}
   <p>{{ self.question }}</p>
   <blockquote class="answer read_only">
     {{ self.student_input|linebreaksbr }}

--- a/mentoring/templates/html/mcqblock_choices.html
+++ b/mentoring/templates/html/mcqblock_choices.html
@@ -1,6 +1,8 @@
 <fieldset class="choices questionnaire">
   <legend class="question">
-    <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+    {% if self.show_title %}
+      <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+    {% endif %}
     <p>{{ self.question }}</p>
   </legend>
   <div class="choices-list">

--- a/mentoring/templates/html/mcqblock_rating.html
+++ b/mentoring/templates/html/mcqblock_rating.html
@@ -1,6 +1,8 @@
 <fieldset class="rating questionnaire">
   <legend class="question">
-    <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+    {% if self.show_title %}
+      <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+    {% endif %}
     <p>{{ self.question }}</p>
   </legend>
   <div class="choices-list">

--- a/mentoring/templates/html/mrqblock_choices.html
+++ b/mentoring/templates/html/mrqblock_choices.html
@@ -1,6 +1,8 @@
 <fieldset class="choices questionnaire" data-hide_results="{{self.hide_results}}">
   <legend class="question">
-    <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+    {% if self.show_title %}
+      <h3 class="question-title">QUESTION {% if not self.lonely_step %}{{ self.step_number }}{% endif %}</h3>
+    {% endif %}
     <p>{{ self.question }}</p>
   </legend>
   <div class="choices-list">

--- a/tests/integration/test_mcq.py
+++ b/tests/integration/test_mcq.py
@@ -170,6 +170,16 @@ class MCQBlockTest(MentoringBaseTest):
         self.assertEqual(mcq_choices_input[2].get_attribute('value'), 'gracefulness')
         self.assertEqual(mcq_choices_input[3].get_attribute('value'), 'bugs')
 
+    @ddt.data(
+        'Mcq Without Title',
+        'Mcq Rating Without Title',
+        'Mrq Without Title'
+    )
+    def test_mcq_without_title(self, page):
+        mentoring = self.go_to_page(page)
+        mcq_legend = mentoring.find_element_by_css_selector('fieldset legend')
+        self.assertNotIn('QUESTION', mcq_legend.text)
+
     def test_mcq_feedback_popups(self):
         mentoring = self.go_to_page('Mcq With Comments 1')
         choices_list = mentoring.find_element_by_css_selector(".choices-list")

--- a/tests/integration/xml/mcq_rating_without_title.xml
+++ b/tests/integration/xml/mcq_rating_without_title.xml
@@ -1,0 +1,12 @@
+<vertical_demo>
+    <mentoring url_name="mcq_with_comments" display_name="MRQ Exercise 7" weight="1" enforce_dependency="false">
+        <mcq name="mcq_1_2" type="rating" low="Not good at all" high="Extremely good" show_title="false">
+            <question>How much do you rate this MCQ?</question>
+            <choice value="notwant">I don't want to rate it</choice>
+
+            <tip display="4,5">I love good grades.</tip>
+            <tip reject="1,2,3">Will do better next time...</tip>
+            <tip reject="notwant">Your loss!</tip>
+        </mcq>
+    </mentoring>
+</vertical_demo>

--- a/tests/integration/xml/mcq_without_title.xml
+++ b/tests/integration/xml/mcq_without_title.xml
@@ -1,0 +1,9 @@
+<vertical_demo>
+    <mentoring url_name="mcq_with_comments" display_name="MRQ Exercise 7" weight="1" enforce_dependency="false">
+        <mcq name="mrq_1_1_7" type="choices" show_title="false">
+            <question>What do you like in this MRQ?</question>
+            <choice value="elegance">Its elegance</choice>
+            <choice value="beauty">Its beauty</choice>
+        </mcq>
+    </mentoring>
+</vertical_demo>

--- a/tests/integration/xml/mrq_without_title.xml
+++ b/tests/integration/xml/mrq_without_title.xml
@@ -1,0 +1,9 @@
+<vertical_demo>
+    <mentoring url_name="mcq_with_comments" display_name="MRQ Exercise 7" weight="1" enforce_dependency="false">
+        <mrq name="mrq_1_1_7" type="choices" show_title="false">
+            <question>What do you like in this MRQ?</question>
+            <choice value="elegance">Its elegance</choice>
+            <choice value="beauty">Its beauty</choice>
+        </mrq>
+    </mentoring>
+</vertical_demo>


### PR DESCRIPTION
A title is shown above each free-form, mcq, and mrq question by default (e.g. QUESTION 3).

This patch adds ability to hide the title on each individual `<answer>`, `<mcq>`, or `<mrq>` block by setting the `show_title` attribute to `"false"`.