### PR TITLE
Fix the position of close tip button.

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,5 +562,5 @@ $ tests/manage.py test --rednose
 License
 -------
 
-The Image Explorer XBlock is available under the GNU Affero General
+The Mentoring XBlock is available under the GNU Affero General
 Public License (AGPLv3).

--- a/mentoring/public/css/questionnaire.css
+++ b/mentoring/public/css/questionnaire.css
@@ -36,9 +36,8 @@
     background: none repeat scroll 0 0 #66A5B5;
     font-family: arial;
     font-size: 14px;
-    overflow-y: auto;
     opacity: 0.9;
-    padding: 10px;
+    padding: 22px 10px;
     width: 300px;
 }
 
@@ -52,6 +51,7 @@
 .mentoring .questionnaire .feedback .tip-choice-group,
 .mentoring .questionnaire .feedback .message-content {
     position: relative;
+    overflow-y: auto;
 }
 
 .mentoring .questionnaire .choice-tips .close,

--- a/mentoring/public/js/questionnaire.js
+++ b/mentoring/public/js/questionnaire.js
@@ -18,8 +18,10 @@ function MessageView(element, mentoring) {
             var data = $(tip).data();
             if (data && data.width) {
                 popupDOM.css('width', data.width);
+                popupDOM.find('.tip-choice-group').css('width', data.width);
             } else {
                 popupDOM.css('width', '');
+                popupDOM.find('.tip-choice-group').css('width', '');
             }
 
             if (data && data.height) {
@@ -27,7 +29,11 @@ function MessageView(element, mentoring) {
                 popupDOM.css('maxHeight', data.height);
             } else {
                 popupDOM.css('height', '');
+                popupDOM.css('maxHeight', '');
             }
+            // .tip-choice-group should always be the same height as the popup
+            // for scrolling to work properly.
+            popupDOM.find('.tip-choice-group').height(popupDOM.height());
 
             popupDOM.show();
 

--- a/mentoring/tip.py
+++ b/mentoring/tip.py
@@ -26,7 +26,7 @@
 import logging
 
 from .light_children import LightChild, Scope, String
-from .utils import loader
+from .utils import loader, ContextConstants
 
 
 # Globals ###########################################################
@@ -64,7 +64,7 @@ class TipBlock(LightChild):
         """
         Returns a fragment containing the formatted tip
         """
-        fragment, named_children = self.get_children_fragment({})
+        fragment, named_children = self.get_children_fragment({ContextConstants.AS_TEMPLATE: False})
         fragment.add_content(loader.render_template('templates/html/tip.html', {
             'self': self,
             'named_children': named_children,


### PR DESCRIPTION
So that if the content of the tip popup overflows the popup,
scrolling the content doesn't also scroll the close button out of view.

Before this patch, the entire popup was scrollable, but this patch
only makes the inner content scrollable, so that the close button stays
in a fixed position (see attached image).

![screen shot 2015-02-28 at 12 02 59](https://cloud.githubusercontent.com/assets/32585/6424919/90b37ca6-bf48-11e4-90ee-9c5144246249.png)
