### PR TITLE
Add nav lock notifications.

### DIFF
--- a/mentoring/public/js/mentoring_assessment_view.js
+++ b/mentoring/public/js/mentoring_assessment_view.js
@@ -29,6 +29,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
     }
 
     function renderGrade() {
+        notify('navigation', {state: 'unlock'})
         var data = $('.grade', element).data();
         data.enable_extended = (no_more_attempts() && data.extended_feedback);
         _.extend(data, {
@@ -70,6 +71,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
             return;
 
         active_child = -1;
+        notify('navigation', {state: 'lock'})
         displayNextChild();
         tryAgainDOM.hide();
         submitDOM.show();
@@ -86,7 +88,15 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         submitXHR = $.post(handlerUrl, JSON.stringify({})).success(handleTryAgain);
     }
 
+    function notify(name, data){
+        // Notification interface does not exist in the workbench.
+        if (runtime.notify) {
+            runtime.notify(name, data)
+        }
+    }
+
     function initXBlockView() {
+        notify('navigation', {state: 'lock'})
         submitDOM = $(element).find('.submit .input-main');
         nextDOM = $(element).find('.submit .input-next');
         reviewDOM = $(element).find('.submit .input-review');


### PR DESCRIPTION
Locks the navigation for supporting runtimes when the block is in an incomplete state.