### PR TITLE
Fix three CSS issues with tip/message popups

### DIFF
--- a/mentoring/mentoring.py
+++ b/mentoring/mentoring.py
@@ -60,6 +60,9 @@ def _is_default_xml_content(value):
     UUID_PATTERN = '[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}'
     DUMMY_UUID = '12345678-1234-1234-1234-123456789abc'
 
+    if value is _default_xml_content:
+        return True
+
     expected = _default_xml_content()
 
     expected = re.sub(UUID_PATTERN, DUMMY_UUID, expected)

--- a/mentoring/public/css/mentoring.css
+++ b/mentoring/public/css/mentoring.css
@@ -135,8 +135,9 @@
 .mentoring .feedback,
 .mentoring .choice-tips {
     min-height: 40px;
-    max-height: 100%;
+    max-height: 180px;
     z-index: 10000;
+    box-sizing: content-box;
 }
 
 .mentoring .review-list {

--- a/mentoring/public/css/questionnaire.css
+++ b/mentoring/public/css/questionnaire.css
@@ -37,7 +37,7 @@
     font-family: arial;
     font-size: 14px;
     opacity: 0.9;
-    padding: 22px 10px;
+    padding: 22px 10px 10px 10px;
     width: 300px;
 }
 
@@ -52,6 +52,8 @@
 .mentoring .questionnaire .feedback .message-content {
     position: relative;
     overflow-y: auto;
+    line-height: normal;
+    max-height: 180px;
 }
 
 .mentoring .questionnaire .choice-tips .close,

--- a/mentoring/public/js/questionnaire.js
+++ b/mentoring/public/js/questionnaire.js
@@ -16,24 +16,24 @@ function MessageView(element, mentoring) {
             // Set the width/height
             var tip = $('.tip', popupDOM)[0];
             var data = $(tip).data();
+            var innerDOM = popupDOM.find('.tip-choice-group');
             if (data && data.width) {
                 popupDOM.css('width', data.width);
-                popupDOM.find('.tip-choice-group').css('width', data.width);
+                innerDOM.css('width', data.width);
             } else {
                 popupDOM.css('width', '');
-                popupDOM.find('.tip-choice-group').css('width', '');
+                innerDOM.css('width', '');
             }
 
             if (data && data.height) {
                 popupDOM.css('height', data.height);
                 popupDOM.css('maxHeight', data.height);
+                innerDOM.css('maxHeight', data.height);
             } else {
                 popupDOM.css('height', '');
                 popupDOM.css('maxHeight', '');
+                innerDOM.css('maxHeight', '');
             }
-            // .tip-choice-group should always be the same height as the popup
-            // for scrolling to work properly.
-            popupDOM.find('.tip-choice-group').height(popupDOM.height());
 
             popupDOM.show();
 

--- a/tests/integration/test_assessment.py
+++ b/tests/integration/test_assessment.py
@@ -288,12 +288,12 @@ class MentoringAssessmentTest(MentoringBaseTest):
         self.assert_hidden(controls.review_link)
 
     def assert_messages_text(self, mentoring, text):
-        messages = mentoring.find_element_by_css_selector('.messages')
+        messages = mentoring.find_element_by_css_selector('.assessment-messages')
         self.assertEqual(messages.text, text)
         self.assertTrue(messages.is_displayed())
 
     def assert_messages_empty(self, mentoring):
-        messages = mentoring.find_element_by_css_selector('.messages')
+        messages = mentoring.find_element_by_css_selector('.assessment-messages')
         self.assertEqual(messages.text, '')
         self.assertFalse(messages.find_elements_by_xpath('./*'))
         self.assertFalse(messages.is_displayed())
@@ -347,7 +347,6 @@ class MentoringAssessmentTest(MentoringBaseTest):
                 "correct": 2, "partial": 1, "incorrect": 1, "percentage": 63,
                 "num_attempts": 1, "max_attempts": 2}
         self.peek_at_review(mentoring, controls, expected_results, extended_feedback=extended_feedback)
-
         self.assert_messages_text(mentoring, "Assessment additional feedback message text")
         self.assert_clickable(controls.try_again)
         controls.try_again.click()


### PR DESCRIPTION
This fixes three CSS issues in xblock-mentoring. See the OC-629 internal ticket for details and links to examples of these problems.

**1. Text was cut off in some popups.** This seems to be caused by the `box-sizing: border-box` global in Apros. I overrode that to `content-box` and it fixes the problem. I also reduced the padding below the tip which was unusually large.

**Before**:
![1-before](https://cloud.githubusercontent.com/assets/945577/7289768/97e7294a-e929-11e4-849f-0bd1b42374cd.png)

**After**:
![1-after](https://cloud.githubusercontent.com/assets/945577/7289771/9e4ebc8a-e929-11e4-9fd9-3bc666a22572.png)


**2. Unwanted scrollbars appearing in feedback popup.**  
If an MCQ had a simple, short `on-submit` message like "Thanks!", a scrollbar would be visible even though the tip box was more than big enough. This was caused by the CSS rule `line-height: 1;` which actually results in a line height smaller than the text (a 14px font actually needs 16px line-height). By overriding with `line-height: normal`, the issue was resolved.


**3. Tip popups containing images are sometimes too small**  
This one was not consistently reproducible - sometimes it would work fine. But when it was occurring, any tip (with no width/height specified in the XML) that contained an image would appear very short initially (only 40px tall). If the tip was then closed and opened again, the height would be correct.

In this case, the problem was this line in the JS:

```javascript
popupDOM.find('.tip-choice-group').height(popupDOM.height());
```

The problem with that is that the `height()` may not be known to the browser immediately, if it is still loading/sizing the image. So it just uses the default `min-height` of `40px`, even if the image subsequently loads and is taller than that. To fix this, I made it so that all tips either always use the default `max-height` of `180px`, or use whatever height is explicitly set in the XML.

**This is a change in behaviour!** Before, tips with no `height` defined would try to have a `max-height: 100%`, i.e. up to the height of the container that they're in (though for some reason in my Chrome this worked out to a max-height of `178px` in practice). But unfortunately you can't have a `max-height: 100%` element inside a `max-height: 100%`, because the inner element needs to know the resulting height of the outer element, which doesn't exist until the inner element has a size, which... [See details here](http://stackoverflow.com/questions/14262938/child-with-max-height-100-overflows-parent). That's why the JavaScript hack was required before, but unfortunately we now know that doesn't work reliably with image content. So I think we have to just manually specify a default maximum height in pixels.

Note that the earlier approach wasn't the best anyways, even if it did work, since `max-height: 100%` could be thousands of pixels, if the container element contains a lot of content (I think? Like I said it was always showing up as 178px to me and I don't know why). What would be ideal is to set the tip max-height to the *visible* height of the parent container. That could be done using jQuery, but would have to be updated if the window sized changed, and would be kind of ugly.

I'm not sure if a default max-height of 180px will be agreeable to everyone or not.

**Before**:
![3-before](https://cloud.githubusercontent.com/assets/945577/7289868/de83ee0a-e92a-11e4-9566-5d298f795536.png)

**After**:
![3-after](https://cloud.githubusercontent.com/assets/945577/7289871/e422cb74-e92a-11e4-9820-b082337a9bd8.png)


I also fixed a minor issue that was preventing the tests from working for me. 