### PR TITLE
Assessment style tweaks - v1 backport

### DIFF
--- a/mentoring/public/css/mentoring.css
+++ b/mentoring/public/css/mentoring.css
@@ -5,9 +5,6 @@
 .mentoring .messages,
 .mentoring .assessment-messages {
     display: none;
-    margin-top: 10px;
-    border-top: 2px solid #eaeaea;
-    padding: 12px 0px 20px;
 }
 
 .mentoring .messages .title1,
@@ -69,7 +66,7 @@
     display: inline-block;
     vertical-align: middle;
     font-size: 13px;
-    font-weight: bold;
+    font-weight: 600;
 }
 
 .mentoring .attempts > span {
@@ -109,6 +106,10 @@
 
 .mentoring .assessment-checkmark {
     margin-right: 10px;
+}
+
+.mentoring .grade .grade-result {
+    margin: 20px;
 }
 
 .mentoring .grade .checkmark-incorrect {
@@ -156,6 +157,11 @@
 .mentoring .results-section {
     float: left;
 }
+
+.mentoring .results-section p {
+    margin: 4px;
+}
+
 .mentoring .clear {
     display: block;
     clear: both;

--- a/mentoring/templates/html/mentoring_grade.html
+++ b/mentoring/templates/html/mentoring_grade.html
@@ -5,15 +5,18 @@
   <p>Note: if you retake this assessment, only your final score counts. If you would like to keep this score,
       please use the arrows below to move on to the next lesson.</p>
   <% }} %>
-  <h2>You scored <%= score %>% on this assessment.</h2>
-  <hr/>
-  <span class="assessment-checkmark icon-2x checkmark-correct icon-ok fa fa-check"></span>
-  <div class="results-section"><p>You answered <%= correct_answer %> questions correctly<%= runDetails('correct') %></div>
-  <div class="clear"></div>
-  <span class="assessment-checkmark icon-2x checkmark-partially-correct icon-ok fa fa-check"></span>
-  <div class="results-section"><p>You answered <%= partially_correct_answer %> questions partially correctly<%= runDetails('partial') %></div>
-  <div class="clear"></div>
-  <span class="assessment-checkmark icon-2x checkmark-incorrect icon-exclamation fa fa-exclamation"></span>
-  <div class="results-section"><p>You answered <%= incorrect_answer %> questions incorrectly<%= runDetails('incorrect') %></div>
-<div class="clear"></div>
+  <div class="grade-result">
+    <h2>You scored <%= score %>% on this assessment.</h2>
+    <hr/>
+    <span class="assessment-checkmark icon-2x checkmark-correct icon-ok fa fa-check"></span>
+    <div class="results-section"><p>You answered <%= correct_answer %> questions correctly<%= runDetails('correct') %></div>
+    <div class="clear"></div>
+    <span class="assessment-checkmark icon-2x checkmark-partially-correct icon-ok fa fa-check"></span>
+    <div class="results-section"><p>You answered <%= partially_correct_answer %> questions partially correctly<%= runDetails('partial') %></div>
+    <div class="clear"></div>
+    <span class="assessment-checkmark icon-2x checkmark-incorrect icon-exclamation fa fa-exclamation"></span>
+    <div class="results-section"><p>You answered <%= incorrect_answer %> questions incorrectly<%= runDetails('incorrect') %></div>
+    <div class="clear"></div>
+    <hr />
+  </div>
 </script>


### PR DESCRIPTION
Backport of https://github.com/open-craft/problem-builder/pull/26

Style tweaks to match more closely the comp:

* Adds horizontal margin on the side of the grades results
* Moves the bottom line separator to the same block (instead of only showing it when the assessment feedback block is shown)
* Reduce the boldness of the text on assessments results

![screenshot-courses mckinseyacademy local 2015-04-30 11-59-37](https://cloud.githubusercontent.com/assets/514483/7410612/c6a4eb70-ef30-11e4-9d25-d980386b9bee.png)