### PR TITLE
Hide "Review final grade" link by default.

### DIFF
--- a/mentoring/public/css/mentoring.css
+++ b/mentoring/public/css/mentoring.css
@@ -163,4 +163,5 @@
 
 .mentoring .review-link {
     float: right;
+    display: none;
 }

--- a/mentoring/public/js/mentoring_assessment_view.js
+++ b/mentoring/public/js/mentoring_assessment_view.js
@@ -109,7 +109,6 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         checkmark = $('.assessment-checkmark', element);
         messagesDOM = $('.assessment-messages', element);
 
-        reviewLinkDOM.hide();
         submitDOM.show();
         submitDOM.bind('click', submit);
         nextDOM.bind('click', displayNextChild);

--- a/mentoring/public/js/mentoring_standard_view.js
+++ b/mentoring/public/js/mentoring_standard_view.js
@@ -75,8 +75,6 @@ function MentoringStandardView(runtime, element, mentoring) {
         submitDOM = $(element).find('.submit .input-main');
         submitDOM.bind('click', submit);
         submitDOM.show();
-        // Not used in standard mode.
-        $(element).find('.review-link').hide()
 
         var options = {
             onChange: onChange


### PR DESCRIPTION
The link is only used during extended feedback in assessment mode.  It's hidden
on page load by JS in all cases, and only shown if the student goes back to a
question after using up all attempts, so we can just as well hide it in CSS.

This fixes MCKIN-3099.