### PR TITLE
Fix importing of light children when URL names in XML.

### DIFF
--- a/mentoring/light_children.py
+++ b/mentoring/light_children.py
@@ -107,7 +107,13 @@ class LightChildrenMixin(XBlockWithChildrenFragmentsMixin):
             cls.add_node_as_child(block, xml_child, child_id)
 
         for name, value in attr:
-            setattr(block, name, value)
+            try:
+                setattr(block, name, value)
+            except AttributeError:
+                # URL name is handled in a special manner, depending on the runtime.
+                if name == 'url_name':
+                    continue
+                raise
 
         return block
 


### PR DESCRIPTION
When importing an adventure XBlock, if the XML content defining children had nodes with URL names, they would not re-import. URL names being present is not always a critical failure, but can be if a block does something special to get around limitations with the attribute for different runtimes.