### PR TITLE
Tests for the two issues when student double-clicks on the submit button

### DIFF
--- a/mentoring/public/js/mentoring_assessment_view.js
+++ b/mentoring/public/js/mentoring_assessment_view.js
@@ -298,7 +298,8 @@ function MentoringAssessmentView(runtime, element, mentoring) {
     }
 
     function submit() {
-        calculate_results('submit', handleSubmitResults)
+        submitDOM.attr('disabled', 'disabled');
+        calculate_results('submit', handleSubmitResults);
     }
 
     function get_results() {


### PR DESCRIPTION
This PR will fix two issues for mentoring xblock, related to student double clicking on submit button. This PR is preliminary --- it solves the issue ASAP, it will be forwarded with much more extensive PR --- that will fix failing tests (failing tests are unrelated to the fix), and fix travis build (travis build is broken for unrelated reasons). 

First issue is when user selects the right answer and then double clicks submit
expected outcome is that green check-mark is displayed, real outcome is that
red cross-mark is displayed, as if the answer was wrong.

Second issue is when student double-clicks on the submit button, expected
outcome is that only a single attempt is "used", real outcome is that
two attempts are used.