### PR TITLE
Re enable submit button if submit handler returns a HTTP exception

### DIFF
--- a/mentoring/public/js/mentoring_assessment_view.js
+++ b/mentoring/public/js/mentoring_assessment_view.js
@@ -284,7 +284,7 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         $('.grade').data(response);
     }
 
-    function calculate_results(handler_name, callback) {
+    function calculate_results(handler_name, success_callback, error_callback) {
         var data = {};
         var child = mentoring.children[active_child];
         if (child && child.name !== undefined) {
@@ -294,12 +294,23 @@ function MentoringAssessmentView(runtime, element, mentoring) {
         if (submitXHR) {
             submitXHR.abort();
         }
-        submitXHR = $.post(handlerUrl, JSON.stringify(data)).success(callback);
+        var opts = {
+            type: "POST",
+            url: handlerUrl,
+            data: JSON.stringify(data),
+            contentType: 'application/json',
+            success: success_callback,
+            error: error_callback
+        };
+        submitXHR = $.ajax(opts)
     }
 
     function submit() {
         submitDOM.attr('disabled', 'disabled');
-        calculate_results('submit', handleSubmitResults);
+        errorCallback = function () {
+            submitDOM.removeAttr("disabled");
+        };
+        calculate_results('submit', handleSubmitResults, errorCallback);
     }
 
     function get_results() {

--- a/tests/integration/test_assessment.py
+++ b/tests/integration/test_assessment.py
@@ -426,6 +426,23 @@ class MentoringAssessmentTest(MentoringAssessmentBaseTest):
         self.wait_for_and_check_single_choice_question_result(
                 mentoring, controls, CORRECT, True)
 
+    def test_unblock_submit_on_error(self):
+        """
+        Test button is re-enabled after an ajax error.
+        """
+
+        self.load_scenario("assessment_2.xml", load_immediately=False)
+        mentoring, controls = self.go_to_assessment()
+
+        self.just_select_on_a_single_choice_question(
+                0, mentoring, controls, "Yes", True)
+        self.timeout = 20
+        with self.settings(ROOT_URLCONF='integration.urls_for_reenable_submit_test'):
+            controls.submit.click()
+            self.wait_until_disabled(controls.submit)
+            enabled_button_selector = '{} .submit input:not([disabled]).input-main'
+            self.wait_until_exists(enabled_button_selector.format(self.default_css_selector))
+
     def test_double_click_uses_only_a_single_attempt(self):
         """
         Double click on submit when selecting a wrong response uses only

--- a/tests/integration/urls_for_reenable_submit_test.py
+++ b/tests/integration/urls_for_reenable_submit_test.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+import time
+
+from django.conf.urls import url
+
+
+def raise_func(*args, **kwargs):
+    # Wait until disabled uses polling, if this function takes
+    # shorter than poll interval we might not observe that
+    # button is disabled. This might be a race condition, but
+    # I didn't find a better way to do it.
+    time.sleep(1)
+    raise ValueError()
+
+urlpatterns = [
+    url(r'.*', raise_func),
+]


### PR DESCRIPTION
Follow up on MCKIN-3719. 

Reproduction steps: 

- Create mentoring block in assesment mode 
- Break submit function on MentoringBlock (add raise ValueError()) 
- After clicking submit the button will stay grayed out 

Verification steps: 

- Import download this PR
- Break submit function on MentoringBlock (add raise ValueError()) 
- After clicking submit the button will be enabled once again